### PR TITLE
Added Ramsey/UUID v4 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "phpspec/phpspec": "^6.1",
         "php": ">=7.1",
-        "ramsey/uuid": "^3.7"
+        "ramsey/uuid": "^3.7|^4.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.16"


### PR DESCRIPTION
Ramsey/UUID is now available in version 4. fortunately for ps-match, there are no BC breaks