### PR TITLE
Upgraded to phpspec 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,8 @@
     ],
     "type": "phpspec-extension",
     "require": {
-        "phpspec/phpspec": "^6.1",
-        "php": ">=7.1",
+        "phpspec/phpspec": "^7.0",
+        "php": ">=7.3",
         "ramsey/uuid": "^3.7|^4.0"
     },
     "require-dev": {


### PR DESCRIPTION
phpspec 7 is the same as 6, but drops support for PHP <7.3 (see: https://github.com/phpspec/phpspec/blob/main/CHANGES-v7.md)